### PR TITLE
inputs/phpfpm_docker: introduce phpfpm plugin with docker

### DIFF
--- a/plugins/inputs/all/all.go
+++ b/plugins/inputs/all/all.go
@@ -138,6 +138,7 @@ import (
 	_ "github.com/influxdata/telegraf/plugins/inputs/pf"
 	_ "github.com/influxdata/telegraf/plugins/inputs/pgbouncer"
 	_ "github.com/influxdata/telegraf/plugins/inputs/phpfpm"
+	_ "github.com/influxdata/telegraf/plugins/inputs/phpfpm_docker"
 	_ "github.com/influxdata/telegraf/plugins/inputs/ping"
 	_ "github.com/influxdata/telegraf/plugins/inputs/postfix"
 	_ "github.com/influxdata/telegraf/plugins/inputs/postgresql"

--- a/plugins/inputs/phpfpm_docker/README.md
+++ b/plugins/inputs/phpfpm_docker/README.md
@@ -1,0 +1,94 @@
+# PHP-FPM Input Plugin With Docker Auto Discovery
+
+Get phpfpm stats using HTTP status page for all fpm containers.
+
+Autodiscovery is maded by looking for configured labels in the containers.
+
+Largely expired by the `phpfpm` and `docker` plugin.
+
+NOTE: Currently only supports `http`.
+
+### Configuration:
+
+```toml
+  ## Docker Endpoint
+  ##   To use TCP, set endpoint = "tcp://[ip]:[port]"
+  ##   To use environment variables (ie, docker-machine), set endpoint = "ENV"
+  docker_endpoint = "unix:///var/run/docker.sock"
+
+  ## Docker Timeout
+  ##   Timeout for connecting to the docker specified endpoint
+  docker_timeout = "10s"
+
+  ## Container Label Enable
+  ##   Define the label name and value that will be used to filter
+  ##   containers to monitor.
+  ##
+  ##   Usage: METRICS_ENABLED=yes
+  ##
+  ##   Then on the docker labels: {
+  ##      name: "METRICS_ENABLED",
+  ##      value: "yes",
+  ##   }
+  container_label_enable = "METRICS_ENABLED=yes"
+
+  ## Container Label Endpoint
+  ##   Define the label variable that will expose the php endpoint
+  ##   Currently only HTTP is supported.
+  ##
+  container_label_exposed_port = "METRICS_EXPOSED_PORT"
+
+  ## Container Label Exposed Path
+  ##   Define the container label that will configure the
+  ##   the http path of phpfpm exposed status.
+  container_label_exposed_path = "METRICS_EXPOSED_PATH"
+
+  ## Container Label Exposed Addr
+  ##   Define which container label will configure the container's endpoint
+  ##   for example: METRICS_EXPOSED_ADDR
+  ##
+  ##   Leave it empty to fetch the container's ipv4 address
+  container_label_exposed_addr = ""
+
+  ## Container Tag Environment Variable
+  ##   Pushing environment variable as tags
+  ##
+  ##   Usage: ["SERVICE_NAME"]
+  container_env_tag = []
+
+  ## Container Label Tag
+  ##   Pushing labels as tags
+  ##
+  ##   Usage: ["Environment"]
+  container_label_tag = []
+```
+
+### Metrics:
+
+- phpfpm
+  - tags:
+    - pool
+    - url
+    - container_id
+  - fields:
+    - accepted_conn
+    - listen_queue
+    - max_listen_queue
+    - listen_queue_len
+    - idle_processes
+    - active_processes
+    - total_processes
+    - max_active_processes
+    - max_children_reached
+    - slow_requests
+
+Additional tags can be added via `container_env_tag` and `container_label_tag`
+variables.
+
+# Example Output
+
+```
+phpfpm_docker,container_id=3f9934367a28b5d2c4e744089a0546c6324ea9071b9f5f8e39741682e7a0f63b,pool=www,url=:9001/status max_active_processes=12i,start_since=10i,listen_queue=0i,active_processes=2i,slow_requests=12i,listen_queue_len=511i,idle_processes=3i,total_processes=4i,accepted_conn=32i,max_children_reached=0i,max_listen_queue=0i 1620479105000000000
+phpfpm_docker,container_id=3f9934367a28b5d2c4e744089a0546c6324ea9071b9f5f8e39741682e7a0f63b,pool=www,url=:9001/status max_active_processes=12i,start_since=10i,listen_queue=0i,active_processes=2i,slow_requests=12i,listen_queue_len=511i,idle_processes=3i,total_processes=4i,accepted_conn=32i,max_children_reached=0i,max_listen_queue=0i 1620479110000000000
+phpfpm_docker,container_id=3f9934367a28b5d2c4e744089a0546c6324ea9071b9f5f8e39741682e7a0f63b,pool=www,url=:9001/status max_active_processes=12i,start_since=10i,listen_queue=0i,active_processes=2i,slow_requests=12i,listen_queue_len=511i,idle_processes=3i,total_processes=4i,accepted_conn=32i,max_children_reached=0i,max_listen_queue=0i 1620479130000000000
+```

--- a/plugins/inputs/phpfpm_docker/docker.go
+++ b/plugins/inputs/phpfpm_docker/docker.go
@@ -1,0 +1,90 @@
+package phpfpm_docker
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/docker/docker/api/types"
+)
+
+type Container struct {
+	endpoint string
+	tags     map[string]string
+}
+
+func (p *PhpFpm) listContainersEndpoints() ([]Container, error) {
+	var containers []Container
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(p.DockerTimeout))
+	defer cancel()
+
+	opts := types.ContainerListOptions{}
+	dockerContainers, err := p.docker.ContainerList(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, container := range dockerContainers {
+		tags := make(map[string]string)
+
+		// Check whether container has the `container_metrics_enabled` label set
+		// and accordinging to the expected configure variable.
+		enabled, found := container.Labels[p.metricsEnabledLabel]
+		if !found || enabled != p.metricsEnabledValue {
+			continue
+		}
+
+		exposedPort, found := container.Labels[p.ContainerLabelExposedPort]
+		if !found {
+			// if we didn't find the exposed port, we should move on
+			continue
+		}
+
+		exposedPath, found := container.Labels[p.ContainerLabelExposedPath]
+		if !found {
+			// if we didn't find the exposed path, we should move on
+			continue
+		}
+
+		info, err := p.docker.ContainerInspect(ctx, container.ID)
+		if err != nil {
+			continue
+		}
+
+		exposedAddr, found := container.Labels[p.ContainerLabelExposedAddr]
+		if !found {
+			// fallback to container's network settings
+			exposedAddr = info.NetworkSettings.DefaultNetworkSettings.IPAddress
+		}
+		endpoint := fmt.Sprintf("http://%s:%s/%s", exposedAddr, exposedPort, exposedPath)
+
+		// add listed labels as metrics tags
+		for _, label := range p.ContainerLabelTag {
+			if value, found := container.Labels[label]; found {
+				tags[label] = value
+			}
+		}
+
+		// add listed envvars as metrics tags
+		for _, envvar := range p.ContainerEnvTag {
+			for _, cEnvName := range info.Config.Env {
+				env := strings.Split(cEnvName, "=")
+				if len(env) == 2 &&
+					len(strings.TrimSpace(env[1])) != 0 &&
+					strings.TrimSpace(env[0]) == envvar {
+					tags[env[0]] = env[1]
+				}
+			}
+		}
+
+		tags["container_id"] = container.ID
+		containers = append(containers, Container{
+			endpoint: endpoint,
+			tags:     tags,
+		})
+	}
+
+	return containers, nil
+}

--- a/plugins/inputs/phpfpm_docker/phpfpm.go
+++ b/plugins/inputs/phpfpm_docker/phpfpm.go
@@ -1,0 +1,174 @@
+package phpfpm_docker
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/influxdata/telegraf"
+	"github.com/influxdata/telegraf/config"
+	"github.com/influxdata/telegraf/plugins/inputs"
+
+	docker "github.com/docker/docker/client"
+)
+
+type PhpFpm struct {
+	DockerEndpoint            string
+	DockerTimeout             config.Duration
+	ContainerLabelEnable      string
+	ContainerLabelEndpoint    []string
+	ContainerEnvTag           []string
+	ContainerLabelTag         []string
+	ContainerLabelExposedPort string
+	ContainerLabelExposedPath string
+	ContainerLabelExposedAddr string
+
+	docker              *docker.Client
+	dockerCtx           context.Context
+	telegraf            telegraf.Accumulator
+	metricsEnabledLabel string
+	metricsEnabledValue string
+}
+
+func (p *PhpFpm) Description() string {
+	return "PhpFpm with docker auto discovery"
+}
+
+var sampleConfig = `
+  ## Docker Endpoint
+  ##   To use TCP, set endpoint = "tcp://[ip]:[port]"
+  ##   To use environment variables (ie, docker-machine), set endpoint = "ENV"
+  docker_endpoint = "unix:///var/run/docker.sock"
+
+  ## Docker Timeout
+  ##   Timeout for connecting to the docker specified endpoint
+  docker_timeout = "10s"
+
+  ## Container Label Enable
+  ##   Define the label name and value that will be used to filter
+  ##   containers to monitor.
+  ##
+  ##   Usage: METRICS_ENABLED=yes
+  ##
+  ##   Then on the docker labels: {
+  ##      name: "METRICS_ENABLED",
+  ##      value: "yes",
+  ##   }
+  container_label_enable = "METRICS_ENABLED=yes"
+
+  ## Container Label Endpoint
+  ##   Define the label variable that will expose the php endpoint
+  ##   Currently only HTTP is supported.
+  ##
+  container_label_exposed_port = "METRICS_EXPOSED_PORT"
+
+  ## Container Label Exposed Path
+  ##   Define the container label that will configure the
+  ##   the http path of phpfpm exposed status.
+  container_label_exposed_path = "METRICS_EXPOSED_PATH"
+
+  ## Container Label Exposed Addr
+  ##   Define which container label will configure the container's endpoint
+  ##   for example: METRICS_EXPOSED_ADDR
+  ##
+  ##   Leave it empty to fetch the container's ipv4 address
+  container_label_exposed_addr = ""
+
+  ## Container Tag Environment Variable
+  ##   Pushing environment variable as tags
+  ##
+  ##   Usage: ["SERVICE_NAME"]
+  container_env_tag = []
+
+  ## Container Label Tag
+  ##   Pushing labels as tags
+  ##
+  ##   Usage: ["Environment"]
+  container_label_tag = []
+`
+
+func (p *PhpFpm) SampleConfig() string {
+	return sampleConfig
+}
+
+func (p *PhpFpm) Init() error {
+	client, err := docker.NewClientWithOpts(docker.FromEnv)
+	if err != nil {
+		return err
+	}
+
+	metricsEnabledLabel := strings.Split(p.ContainerLabelEnable, "=")
+	if len(metricsEnabledLabel) != 2 {
+		return fmt.Errorf("container_label_enable is not properly undefined: %s", p.ContainerLabelEnable)
+	}
+
+	p.docker = client
+	p.metricsEnabledLabel = metricsEnabledLabel[0]
+	p.metricsEnabledValue = metricsEnabledLabel[1]
+	return nil
+}
+
+// outputMetric parses the response text from the phpfpm and
+// adds the tags and fields on the `telegraf.Accumulator` buffer.
+// function impired by the ../phpfpm plugin
+func (p *PhpFpm) outputMetric(r io.Reader, addr string, addTags map[string]string) {
+	stats, err := p.parsePhpfpmStats(&r)
+	if err != nil {
+		fmt.Errorf("not able to parse stats")
+	}
+
+	// We push the pool metric to telegraf
+	for pool := range stats {
+		tags := map[string]string{
+			"pool": pool,
+			"url":  addr,
+		}
+		for k, v := range addTags {
+			tags[k] = v
+		}
+
+		fields := make(map[string]interface{})
+		for k, v := range stats[pool] {
+			fields[strings.Replace(k, " ", "_", -1)] = v
+		}
+
+		p.telegraf.AddFields("phpfpm_docker", fields, tags)
+	}
+}
+
+func (p *PhpFpm) Gather(acc telegraf.Accumulator) error {
+	// ensure our instruct points to the telegraf metrics buffer
+	p.telegraf = acc
+
+	containers, err := p.listContainersEndpoints()
+	if err != nil {
+		return err
+	}
+
+	for _, c := range containers {
+		response, err := p.requestHttp(c.endpoint)
+		if err == nil {
+			defer response.Close()
+			p.outputMetric(response, c.endpoint, c.tags)
+		}
+	}
+
+	return nil
+}
+
+func init() {
+	inputs.Add("phpfpm_docker", func() telegraf.Input {
+		return &PhpFpm{
+			DockerEndpoint:            "unix:///var/run/docker.sock",
+			DockerTimeout:             config.Duration(time.Second * 5),
+			ContainerLabelEnable:      "METRICS_ENABLED=yes",
+			ContainerLabelExposedPort: "METRICS_EXPOSED_PORT",
+			ContainerLabelExposedPath: "METRICS_EXPOSED_PATH",
+			ContainerLabelExposedAddr: "METRICS_EXPOSED_ADDRESS",
+			ContainerEnvTag:           []string{},
+			ContainerLabelTag:         []string{},
+		}
+	})
+}

--- a/plugins/inputs/phpfpm_docker/request.go
+++ b/plugins/inputs/phpfpm_docker/request.go
@@ -1,0 +1,97 @@
+package phpfpm_docker
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const (
+	PfPool               = "pool"
+	PfProcessManager     = "process manager"
+	PfStartSince         = "start since"
+	PfAcceptedConn       = "accepted conn"
+	PfListenQueue        = "listen queue"
+	PfMaxListenQueue     = "max listen queue"
+	PfListenQueueLen     = "listen queue len"
+	PfIdleProcesses      = "idle processes"
+	PfActiveProcesses    = "active processes"
+	PfTotalProcesses     = "total processes"
+	PfMaxActiveProcesses = "max active processes"
+	PfMaxChildrenReached = "max children reached"
+	PfSlowRequests       = "slow requests"
+)
+
+type metric map[string]int64
+type poolStat map[string]metric
+
+func (p *PhpFpm) requestHttp(addr string) (r io.ReadCloser, err error) {
+	u, err := url.Parse(addr)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse server address '%s': %v", addr, err)
+	}
+
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create a request to '%s': '%v'", addr, err)
+	}
+
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("unable to perform a request to '%s': '%v'", addr, err)
+	}
+
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("http request invalid error to '%d': '%v'", res.StatusCode, err)
+	}
+
+	return res.Body, nil
+}
+
+func (p *PhpFpm) parsePhpfpmStats(r *io.Reader) (poolStat, error) {
+	var currentPool string
+	stats := make(poolStat)
+
+	scanner := bufio.NewScanner(*r)
+	for scanner.Scan() {
+		line := strings.Split(scanner.Text(), ":")
+		if len(line) > 2 {
+			continue
+		}
+
+		key, value := strings.Trim(line[0], " "), strings.Trim(line[1], " ")
+
+		if key == PfPool {
+			currentPool = value
+			stats[currentPool] = make(metric)
+			continue
+		}
+
+		if stats[currentPool] != nil {
+			switch key {
+			case PfStartSince,
+				PfAcceptedConn,
+				PfListenQueue,
+				PfMaxListenQueue,
+				PfListenQueueLen,
+				PfIdleProcesses,
+				PfActiveProcesses,
+				PfTotalProcesses,
+				PfMaxActiveProcesses,
+				PfMaxChildrenReached,
+				PfSlowRequests:
+				valueInt, err := strconv.ParseInt(value, 10, 64)
+				if err == nil {
+					stats[currentPool][key] = valueInt
+				}
+			}
+		}
+	}
+
+	return stats, nil
+}


### PR DESCRIPTION
The phpfpm plugins connects to the defined endpoints and collect
phpfpm metrics exposed by the service. The plugin, however, doesn't
support auto discovery mechanism, specially in container workloads.

As the plugin configuration is static, one have to create a external
configuration tool that will perform the auto discovery and generate
the phpfpm's expected configuration.

In order to support a containered dynamic environment, let's introduce
a new plugin that will perform the docker auto discovery based on
container's label that will automatically collect phpfpm metrics.

### Required for all PRs:

<!-- Complete the tasks in the following list. Change [ ] to [x] to
show completion. -->

- [ ] Updated associated README.md.
- [ ] Wrote appropriate unit tests.

<!-- Link to issues that describe the need for the change. Issues
should include context that will help reviewers understand why the
change is needed.

Make sure to link issues and using a keyword like "resolves #1234".
https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword
-->

resolves #

<!-- Finally, include a summary of the code change itself. This
description should tell reviewers how the issues were resolved.

example: Fixed an off by one error in counter variable in type FooBar.

example: Added an input plugin to gather yak shaving metrics using
golang library yaktech/shaver. -->
